### PR TITLE
[FIXED] Potential fix for https://github.com/hossain-khan/android-hk-…

### DIFF
--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -31,10 +31,11 @@ jobs:
         with:
           node-version: '20.x'
 
-      # # Installs the fast-xml-parser globally using npm
+      # Installs the fast-xml-parser globally using npm
+      # Uses older build to avoid `package.json` lookup issue
       # https://www.npmjs.com/package/fast-xml-parser
       - name: Install XML Validator
-        run: npm install -g fast-xml-parser
+        run: npm install -g fast-xml-parser@4.5.2
 
       # PoC: Validates the AndroidManifest.xml file using fast-xml-parser
       - name: Validate AndroidManifest.xml

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ app/release/
 .idea/deploymentTargetSelector.xml
 .idea/other.xml
 *.salive
+.idea/AndroidProjectSystem.xml


### PR DESCRIPTION
…vision-muzei-plugin/actions/runs/13689752545/job/38280699282

Run fxparser -V app/src/main/AndroidManifest.xml
node:fs:574
  return binding.open(
                 ^

Error: ENOENT: no such file or directory, open '/home/runner/work/android-hk-vision-muzei-plugin/android-hk-vision-muzei-plugin/package.json'
    at Object.openSync (node:fs:574:18)
    at Object.readFileSync (node:fs:453:35)
    at file:///opt/hostedtoolcache/node/20.18.3/x64/lib/node_modules/fast-xml-parser/src/cli/man.js:4:31
    at ModuleJob.run (node:internal/modules/esm/module_job:234:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:473:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:122:5) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/home/runner/work/android-hk-vision-muzei-plugin/android-hk-vision-muzei-plugin/package.json'
}

Node.js v20.18.3
Error: Process completed with exit code 1.